### PR TITLE
Support base32 lower case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 [dependencies]
 base-x = "0.2"
 data-encoding = "2.1.2"
+data-encoding-macro = "0.1.7"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ readme = "README.md"
 
 [dependencies]
 base-x = "0.2"
-base32 = "0.4"
-base64 = "0.10"
+data-encoding = "2.1.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,4 +1,5 @@
 use crate::{Error, Result};
+use data_encoding::{BASE32_NOPAD, BASE32, BASE64, BASE64_NOPAD, BASE64URL, BASE64URL_NOPAD};
 
 trait BaseImpl {
     /// Encode a byte slice.
@@ -97,15 +98,11 @@ pub struct Base32UpperNoPad;
 
 impl BaseImpl for Base32UpperNoPad {
     fn encode(input: &[u8]) -> String {
-        base32::encode(base32::Alphabet::RFC4648 { padding: false }, input)
+        BASE32_NOPAD.encode(input)
     }
 
     fn decode(input: &str) -> Result<Vec<u8>> {
-        if let Some(result) = base32::decode(base32::Alphabet::RFC4648 { padding: false }, input) {
-            Ok(result)
-        } else {
-            Err(Error::InvalidBaseString)
-        }
+        Ok(BASE32_NOPAD.decode(input.as_bytes())?)
     }
 }
 
@@ -115,15 +112,11 @@ pub struct Base32UpperPad;
 
 impl BaseImpl for Base32UpperPad {
     fn encode(input: &[u8]) -> String {
-        base32::encode(base32::Alphabet::RFC4648 { padding: true }, input)
+        BASE32.encode(input)
     }
 
     fn decode(input: &str) -> Result<Vec<u8>> {
-        if let Some(result) = base32::decode(base32::Alphabet::RFC4648 { padding: true }, input) {
-            Ok(result)
-        } else {
-            Err(Error::InvalidBaseString)
-        }
+        Ok(BASE32.decode(input.as_bytes())?)
     }
 }
 
@@ -133,12 +126,11 @@ pub struct Base64UpperNoPad;
 
 impl BaseImpl for Base64UpperNoPad {
     fn encode(input: &[u8]) -> String {
-        base64::encode_config(input, base64::STANDARD_NO_PAD)
+        BASE64_NOPAD.encode(input)
     }
 
     fn decode(input: &str) -> Result<Vec<u8>> {
-        let result = base64::decode_config(input, base64::STANDARD_NO_PAD)?;
-        Ok(result)
+        Ok(BASE64_NOPAD.decode(input.as_bytes())?)
     }
 }
 
@@ -148,12 +140,11 @@ pub struct Base64UpperPad;
 
 impl BaseImpl for Base64UpperPad {
     fn encode(input: &[u8]) -> String {
-        base64::encode_config(input, base64::STANDARD)
+        BASE64.encode(input)
     }
 
     fn decode(input: &str) -> Result<Vec<u8>> {
-        let result = base64::decode_config(input, base64::STANDARD)?;
-        Ok(result)
+        Ok(BASE64.decode(input.as_bytes())?)
     }
 }
 
@@ -163,12 +154,11 @@ pub struct Base64UrlUpperNoPad;
 
 impl BaseImpl for Base64UrlUpperNoPad {
     fn encode(input: &[u8]) -> String {
-        base64::encode_config(input, base64::URL_SAFE_NO_PAD)
+        BASE64URL_NOPAD.encode(input)
     }
 
     fn decode(input: &str) -> Result<Vec<u8>> {
-        let result = base64::decode_config(input, base64::URL_SAFE_NO_PAD)?;
-        Ok(result)
+        Ok(BASE64URL_NOPAD.decode(input.as_bytes())?)
     }
 }
 
@@ -178,12 +168,11 @@ pub struct Base64UrlUpperPad;
 
 impl BaseImpl for Base64UrlUpperPad {
     fn encode(input: &[u8]) -> String {
-        base64::encode_config(input, base64::URL_SAFE)
+        BASE64URL.encode(input)
     }
 
     fn decode(input: &str) -> Result<Vec<u8>> {
-        let result = base64::decode_config(input, base64::URL_SAFE)?;
-        Ok(result)
+        Ok(BASE64URL.decode(input.as_bytes())?)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,8 +33,8 @@ impl From<base_x::DecodeError> for Error {
     }
 }
 
-impl From<base64::DecodeError> for Error {
-    fn from(_: base64::DecodeError) -> Self {
+impl From<data_encoding::DecodeError> for Error {
+    fn from(_: data_encoding::DecodeError) -> Self {
         Self::InvalidBaseString
     }
 }


### PR DESCRIPTION
Fixes #14

Switched out `base32` and `base64` for `data-encoding`.

These are the `cargo bench` numbers for the base32 and base64 encoding, indicating an improvement for base32 but no change for base64.

```
base32                  time:   [851.63 ns 856.51 ns 861.97 ns]
                        change: [-64.295% -63.429% -62.499%] (p = 0.00 < 0.05)
                        Performance has improved.
```
```
base64                  time:   [709.00 ns 713.63 ns 718.66 ns]
                        change: [-4.4352% -1.7143% +0.9702%] (p = 0.24 > 0.05)
                        No change in performance detected.
```
```
base32 #2               time:   [715.94 ns 720.01 ns 724.27 ns]
                        change: [-70.740% -69.963% -69.087%] (p = 0.00 < 0.05)
                        Performance has improved.
```
```
base64 #2               time:   [689.02 ns 693.31 ns 698.03 ns]
                        change: [-0.1482% +2.9142% +6.0073%] (p = 0.07 > 0.05)
                        No change in performance detected.
```
