### PR TITLE
Set crate repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT"
 readme = "README.md"
 description = "multibase in rust"
-homepage = "https://github.com/multiformats/rust-multibase"
+repository = "https://github.com/multiformats/rust-multibase"
 keywords = ["ipld", "ipfs", "multihash", "multibase", "cid"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MIT"
 readme = "README.md"
 description = "multibase in rust"
+homepage = "https://github.com/multiformats/rust-multibase"
 repository = "https://github.com/multiformats/rust-multibase"
 keywords = ["ipld", "ipfs", "multihash", "multibase", "cid"]
 


### PR DESCRIPTION
It was set as homepage before, but was really pointing to this repository. 

This broke some tools that rely on the `repository` field, and now will show up with better link name in crates.io