### PR TITLE
Remove internal encoding import

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.11.0'
           args: '-- --test-threads 1'
 
       - name: Upload to codecov.io

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,5 +1,5 @@
 use data_encoding::Encoding;
-use data_encoding_macro::{internal_new_encoding, new_encoding};
+use data_encoding_macro::new_encoding;
 
 // Base2 (alphabet: 01)
 pub const BASE2: Encoding = new_encoding! {


### PR DESCRIPTION
After merging #28, the CI failed. It wasn't introduced by this change, but HEAD should always be green.

@mriise would you mind reviewing this PR?