### PR TITLE
chore: remove one keyword

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 description = "multibase in rust"
 homepage = "https://github.com/multiformats/rust-multibase"
 repository = "https://github.com/multiformats/rust-multibase"
-keywords = ["ipld", "ipfs", "multihash", "multibase", "cid", "no_std"]
+keywords = ["ipld", "ipfs", "multihash", "cid", "no_std"]
 
 [features]
 default = ["std"]


### PR DESCRIPTION
A crate may only contain 5 keywords at most when published. I thought
removing `multibase` is a good idea as the crate already has that name
anyway.

The error message from the crates.io API was:

    error: api errors (status 200 OK): invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 4205