### PR TITLE
Allow cli/ tool to read data from stdin

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -20,15 +20,15 @@ enum Mode {
         /// The base to use for encoding.
         #[structopt(short = "b", long = "base", default_value = "base58btc")]
         base: StrBase,
-        /// The data need to be encoded.
+        /// The data to encode. Reads from stdin if not provided.
         #[structopt(short = "i", long = "input")]
-        input: String,
+        input: Option<String>,
     },
     #[structopt(name = "decode")]
     Decode {
-        /// The data need to be decoded.
+        /// The data to decode. Reads from stdin if not provided.
         #[structopt(short = "i", long = "input")]
-        input: String,
+        input: Option<String>,
     },
 }
 
@@ -36,8 +36,28 @@ fn main() -> Result<()> {
     env_logger::init();
     let opts = Opts::from_args();
     match opts.mode {
-        Mode::Encode { base, input } => encode(base, input.as_bytes()),
-        Mode::Decode { input } => decode(&input),
+        Mode::Encode { base, input } => {
+            let input_bytes = match input {
+                Some(s) => s.into_bytes(),
+                None => {
+                    let mut buf = Vec::new();
+                    io::stdin().read_to_end(&mut buf)?;
+                    buf
+                }
+            };
+            encode(base, &input_bytes)
+        }
+        Mode::Decode { input } => {
+            let input_str = match input {
+                Some(s) => s,
+                None => {
+                    let mut buf = String::new();
+                    io::stdin().read_to_string(&mut buf)?;
+                    buf
+                }
+            };
+            decode(&input_str)
+        }
     }
 }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::io::{self, Read, Write};
 use std::str::FromStr;
 
 use anyhow::{anyhow, Error, Result};
@@ -119,13 +120,13 @@ impl From<StrBase> for Base {
 fn encode(base: StrBase, input: &[u8]) -> Result<()> {
     log::debug!("Encode {:?} with {}", input, base);
     let result = multibase::encode(base.into(), input);
-    println!("Result: {}", result);
+    print!("{}", result);
     Ok(())
 }
 
 fn decode(input: &str) -> Result<()> {
     log::debug!("Decode {:?}", input);
-    let (base, result) = multibase::decode(input)?;
-    println!("Result: {}, {:?}", StrBase(base), result);
+    let (_, result) = multibase::decode(input)?;
+    io::stdout().write_all(&result)?;
     Ok(())
 }


### PR DESCRIPTION
The executable in `cli/` is a nice little conversion tool: much lighter than depending on Kubo, and supports more bases than other CLIs I've found. I'm not sure if anybody's actually using it for anything, but I'd like to; however, it does a couple of things which make it unsuitable for scripting. These commits scratch that itch, so I thought I'd upstream them. If it's not appropriate then feel free to ignore me :-)

 - Taking data from arguments, but not stdin. This is especially problematic for `encode`, since binary data (which may contain NUL bytes, etc.) doesn't work well in argument lists; it forces shell scripts to use variables, which can't store it correctly; etc. In contrast, stdio is binary-safe, and requires no variables.
 - Outputting more than just the raw data, e.g. including a `Result: ` prefix. This makes it less useful for programmatic use.

With these changes, the `multibase` executable feels more like a member of coreutils (e.g. `base64`), and is much easier to plug into other tools.

PS: I'm not a Rust programmer, so might have made some mistakes. It would also be nice to stream the stdio conversion, rather than reading it all into memory; but this is a less invasive change, and fine for my current needs, at least.